### PR TITLE
perflint: Add ruff rules for performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.10
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
@@ -13,6 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+        args: [--maxkb=5000]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -20,4 +21,3 @@ repos:
       - id: codespell # See pyproject.toml for args
         additional_dependencies:
           - tomli
-        args: [--maxkb=5000]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,13 +154,14 @@ exclude = ["tests/artifacts/**/*.safetensors", "*_pb2.py", "*_pb2_grpc.py"]
 # N: pep8-naming
 # TODO: Uncomment rules when ready to use
 select = [
-    "E", "W", "F", "I", "B", "C4", "T20", "N" # "SIM", "A", "S", "D", "RUF", "UP"
+    "ASYNC", "B", "C4", "E", "F", "I", "N", "PERF", "T20", "W" # "A", "D", "RUF", "S", "SIM", "UP"
 ]
 ignore = [
+    "B008", # Perform function call in argument defaults
     "E501", # Line too long
+    "PERF203", # try-except-in-loop
     "T201", # Print statement found
     "T203", # Pprint statement found
-    "B008", # Perform function call in argument defaults
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/beavr/lerobot/common/policies/smolvla/smolvlm_with_expert.py
+++ b/src/beavr/lerobot/common/policies/smolvla/smolvlm_with_expert.py
@@ -157,8 +157,7 @@ class SmolVLMWithExpertModel(nn.Module):
                 "lm_head",
                 "text_model.model.norm.weight",
             ]
-            for layer in last_layers:
-                frozen_layers.append(f"text_model.model.layers.{layer}.")
+            frozen_layers.extend(f"text_model.model.layers.{layer}." for layer in last_layers)
 
             for name, params in self.vlm.named_parameters():
                 if any(k in name for k in frozen_layers):

--- a/src/beavr/lerobot/common/robot_devices/cameras/opencv.py
+++ b/src/beavr/lerobot/common/robot_devices/cameras/opencv.py
@@ -46,34 +46,31 @@ MAX_OPENCV_INDEX = 60
 
 
 def find_cameras(raise_when_empty=False, max_index_search_range=MAX_OPENCV_INDEX, mock=False) -> list[dict]:
-    cameras = []
     if platform.system() == "Linux":
         print("Linux detected. Finding available camera indices through scanning '/dev/video*' ports")
         possible_ports = [str(port) for port in Path("/dev").glob("video*")]
         ports = _find_cameras(possible_ports, mock=mock)
-        for port in ports:
-            cameras.append(
-                {
-                    "port": port,
-                    "index": int(port.removeprefix("/dev/video")),
-                }
-            )
-    else:
-        print(
-            "Mac or Windows detected. Finding available camera indices through "
-            f"scanning all indices from 0 to {MAX_OPENCV_INDEX}"
-        )
-        possible_indices = range(max_index_search_range)
-        indices = _find_cameras(possible_indices, mock=mock)
-        for index in indices:
-            cameras.append(
-                {
-                    "port": None,
-                    "index": index,
-                }
-            )
+        return [
+            {
+                "port": port,
+                "index": int(port.removeprefix("/dev/video")),
+            }
+            for port in ports
+        ]
 
-    return cameras
+    print(
+        "Mac or Windows detected. Finding available camera indices through "
+        f"scanning all indices from 0 to {MAX_OPENCV_INDEX}"
+    )
+    possible_indices = range(max_index_search_range)
+    indices = _find_cameras(possible_indices, mock=mock)
+    return [
+        {
+            "port": None,
+            "index": index,
+        }
+        for index in indices
+    ]
 
 
 def _find_cameras(

--- a/src/beavr/lerobot/common/robot_devices/robots/beavrbot.py
+++ b/src/beavr/lerobot/common/robot_devices/robots/beavrbot.py
@@ -457,7 +457,7 @@ class BeavrBot(Robot):
             logging.warning("WARNING: Not all subscribers acknowledged teleop stop – proceeding anyway")
 
         # Send home signals
-        for _, home_info in self.home_publishers.items():
+        for home_info in self.home_publishers.values():
             self.pub_manager.publish(
                 home_info["host"],
                 home_info["port"],
@@ -486,7 +486,7 @@ class BeavrBot(Robot):
             logging.warning("WARNING: Not all subscribers acknowledged teleop resume – proceeding anyway")
 
         # Send home signals
-        for _, home_info in self.home_publishers.items():
+        for home_info in self.home_publishers.values():
             self.pub_manager.publish(
                 home_info["host"],
                 home_info["port"],

--- a/src/beavr/lerobot/common/robot_devices/robots/manipulator.py
+++ b/src/beavr/lerobot/common/robot_devices/robots/manipulator.py
@@ -502,17 +502,11 @@ class ManipulatorRobot:
             self.logs[f"read_follower_{name}_pos_dt_s"] = time.perf_counter() - before_fread_t
 
         # Create state by concatenating follower current position
-        state = []
-        for name in self.follower_arms:
-            if name in follower_pos:
-                state.append(follower_pos[name])
+        state = [follower_pos[name] for name in self.follower_arms if name in follower_pos]
         state = torch.cat(state)
 
         # Create action by concatenating follower goal position
-        action = []
-        for name in self.follower_arms:
-            if name in follower_goal_pos:
-                action.append(follower_goal_pos[name])
+        action = [follower_goal_pos[name] for name in self.follower_arms if name in follower_goal_pos]
         action = torch.cat(action)
 
         # Capture images from cameras
@@ -549,10 +543,7 @@ class ManipulatorRobot:
             self.logs[f"read_follower_{name}_pos_dt_s"] = time.perf_counter() - before_fread_t
 
         # Create state by concatenating follower current position
-        state = []
-        for name in self.follower_arms:
-            if name in follower_pos:
-                state.append(follower_pos[name])
+        state = [follower_pos[name] for name in self.follower_arms if name in follower_pos]
         state = torch.cat(state)
 
         # Capture images from cameras

--- a/src/beavr/lerobot/common/robot_devices/robots/mobile_manipulator.py
+++ b/src/beavr/lerobot/common/robot_devices/robots/mobile_manipulator.py
@@ -180,12 +180,9 @@ class MobileManipulator:
 
     @property
     def available_arms(self):
-        available = []
-        for name in self.leader_arms:
-            available.append(get_arm_id(name, "leader"))
-        for name in self.follower_arms:
-            available.append(get_arm_id(name, "follower"))
-        return available
+        return [get_arm_id(name, "leader") for name in self.leader_arms] + [
+            get_arm_id(name, "follower") for name in self.follower_arms
+        ]
 
     def on_press(self, key):
         try:

--- a/src/beavr/lerobot/configs/policies.py
+++ b/src/beavr/lerobot/configs/policies.py
@@ -117,14 +117,14 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     @property
     def robot_state_feature(self) -> PolicyFeature | None:
-        for _, ft in self.input_features.items():
+        for ft in self.input_features.values():
             if ft.type is FeatureType.STATE:
                 return ft
         return None
 
     @property
     def env_state_feature(self) -> PolicyFeature | None:
-        for _, ft in self.input_features.items():
+        for ft in self.input_features.values():
             if ft.type is FeatureType.ENV:
                 return ft
         return None
@@ -135,7 +135,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     @property
     def action_feature(self) -> PolicyFeature | None:
-        for _, ft in self.output_features.items():
+        for ft in self.output_features.values():
             if ft.type is FeatureType.ACTION:
                 return ft
         return None

--- a/src/beavr/teleop/components/operator/solvers/leap_solver.py
+++ b/src/beavr/teleop/components/operator/solvers/leap_solver.py
@@ -221,7 +221,7 @@ class LeapHandIKSolver:
 
         # Update with the provided finger positions
         for finger, positions in finger_positions.items():
-            full_finger_positions[finger] = positions
+            full_finger_positions[finger] = positions  # noqa: PERF403
 
         # Check which fingers are active (have positions)
         active_fingers = {


### PR DESCRIPTION
## What this does

perflint: Add ruff rules for performance -- https://docs.astral.sh/ruff/rules/#perflint-perf

---

## How it was tested

% `pre-commit run --all-files`

% `ruff rule PERF401`
# manual-list-comprehension (PERF401)

Derived from the **Perflint** linter.

Fix is sometimes available.

## What it does
Checks for `for` loops that can be replaced by a list comprehension.

## Why is this bad?
When creating a transformed list from an existing list using a for-loop,
prefer a list comprehension. List comprehensions are more readable and
more performant.

Using the below as an example, the list comprehension is ~10% faster on
Python 3.11, and ~25% faster on Python 3.10.

Note that, as with all `perflint` rules, this is only intended as a
micro-optimization, and will have a negligible impact on performance in
most cases.

## Example
```python
original = list(range(10000))
filtered = []
for i in original:
    if i % 2:
        filtered.append(i)
```

Use instead:
```python
original = list(range(10000))
filtered = [x for x in original if x % 2]
```

If you're appending to an existing list, use the `extend` method instead:
```python
original = list(range(10000))
filtered.extend(x for x in original if x % 2)
```